### PR TITLE
Handle trailing endregion

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -113,7 +113,15 @@ export class SymbolNode {
 				const docSymbol = docSymbols[i];
 				for (let j = i + 1; j < docSymbols.length; j++) {
 					const sibling = docSymbols[j];
-					if (docSymbol.range.contains(sibling.range)) {
+					// The second clause handles the case when the sibling is a region,
+					// so the "endregion" might not be contained by the docSymbol.range
+					if (
+						docSymbol.range.contains(sibling.range) ||
+						(
+							docSymbol.range.contains(sibling.range.start) &&
+							sibling.detail === "__om_Region__"
+						)
+					) {
 						docSymbol.children.push(sibling);
 						docSymbols.splice(j, 1);
 						j--;


### PR DESCRIPTION
This addresses #56.

DocumentSymbols won't include regions in their ranges, so an "endregion" at the end of a scope gets skipped.

This changes the check for just the start range, if the sibling is a `__om_Region__`.

This was only an issue in languages like python that don't have a closing character for scopes.